### PR TITLE
Support Symfony 8 / Laravel 13 / PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,35 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
     strategy:
+      fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
         laravel: ['10.*', '11.*', '12.*', '13.*']
+        include:
+          - laravel: '10.*'
+            testbench: '8.*'
+          - laravel: '11.*'
+            testbench: '9.*'
+          - laravel: '12.*'
+            testbench: '10.*'
+          - laravel: '13.*'
+            testbench: '11.*'
+        exclude:
+          # Laravel 13 (Symfony 8) requires PHP >= 8.3
+          - laravel: '13.*'
+            php: '8.2'
+          # Laravel 10 is not supported on PHP 8.4 / 8.5
+          - laravel: '10.*'
+            php: '8.4'
+          - laravel: '10.*'
+            php: '8.5'
+          # Laravel 11 is not supported on PHP 8.5
+          - laravel: '11.*'
+            php: '8.5'
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +44,11 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require --dev --no-update \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}"
+          composer update --no-interaction --prefer-dist --with-all-dependencies
 
       - name: Run tests
         run: ./vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "nikic/php-parser": "^5.0",
-    "symfony/console": "^6.0|^7.0",
-    "symfony/finder": "^6.0|^7.0"
+    "symfony/console": "^6.0|^7.0|^8.0",
+    "symfony/finder": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",


### PR DESCRIPTION
The package declares support for "Laravel 10|11|12|13" but is **not installable on Laravel 13**. Laravel 13 is built on Symfony 8, while the package constrains the Symfony components to `^6.0|^7.0`, which excludes `^8.0`:

```
  techrays-labs/laravel-debt-tracker v1.0.0
    requires symfony/console ^6.0|^7.0
    → but Laravel 13 ships symfony/console v8.x
  Your requirements could not be resolved to an installable set of packages.
```

## Changes

  - **`composer.json`** — widen the Symfony constraints to include `^8.0`:
    - `symfony/console: ^6.0|^7.0|^8.0`
    - `symfony/finder: ^6.0|^7.0|^8.0`

    (`illuminate/*` already allows `^13.0` and `php: ^8.2` already covers 8.5, so no
    change needed there.)

  - **CI (`.github/workflows/tests.yml`)** — add PHP 8.5 and actually pin the
    Laravel/Testbench version per matrix cell (the `laravel` axis was previously inert
    because the workflow only ran `composer install`). Added `exclude` rules for the
    unsupported PHP/Laravel combinations (e.g. Laravel 13 requires PHP ≥ 8.3).